### PR TITLE
Support wildcards in unaffected paths.

### DIFF
--- a/splash/models.py
+++ b/splash/models.py
@@ -26,7 +26,8 @@ class SplashConfig(ConfigurationModel):
     unaffected_url_paths = models.TextField(
         default='',
         blank=True,
-        help_text="Comma-separated list of URL paths (not including the hostname) which should not be redirected"
+        help_text="Comma-separated list of URL paths (not including the hostname) which should not be redirected. "
+                  "Paths may include wildcards denoted by * (example: /*/student_view)"
     )
     redirect_url = models.URLField(
         default='http://edx.org',


### PR DESCRIPTION
This commit adds ability to use wildcards denoted by the '*' character
in unaffected paths. The wildcard will match a sequence of zero
or more arbitrary characters.

Example: /*/student_view
